### PR TITLE
Add new class names introduced in recent version

### DIFF
--- a/wcs-disable-report-cache-update.php
+++ b/wcs-disable-report-cache-update.php
@@ -38,6 +38,10 @@ function wcs_disable_report_cache_update() {
 		'WC_Report_Upcoming_Recurring_Revenue',
 		'WC_Report_Subscription_By_Product',
 		'WC_Report_Subscription_By_Customer',
+		'WCS_Report_Subscription_Events_By_Date',
+		'WCS_Report_Upcoming_Recurring_Revenue',
+		'WCS_Report_Subscription_By_Product',
+		'WCS_Report_Subscription_By_Customer',
 	);
 
 	foreach ( $cached_report_classes as $report_class ) {


### PR DESCRIPTION
I'm not sure which version of _Subscriptions_ changed the class names, but it's clear that the prefix was changed from `WC_` to `WCS_`. Adding the new class names (rather than replacing the old ones) keeps the plugin functional with versions prior to the class name adjustment.